### PR TITLE
Remove extra stability attributes

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -16,9 +16,6 @@
 //! general, and allows for generating values that change some state
 //! internally. The `IndependentSample` trait is for generating values
 //! that do not need to record state.
-
-#![unstable(feature = "rand")]
-
 use core::prelude::*;
 use core::num::{Float, Int};
 

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -141,9 +141,7 @@ impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {
         *rng = Default::default();
     }
 }
-#[stable(feature = "rust1", since = "1.0.0")]
 impl Default for ReseedWithDefault {
-    #[stable(feature = "rust1", since = "1.0.0")]
     fn default() -> ReseedWithDefault { ReseedWithDefault }
 }
 


### PR DESCRIPTION
These are not necessary since the crate doesn’t participate in staged_api