### PR TITLE
Remove weak_rng

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,22 +740,6 @@ impl<'a> SeedableRng<&'a [usize]> for StdRng {
     }
 }
 
-/// Create a weak random number generator with a default algorithm and seed.
-///
-/// It returns the fastest `Rng` algorithm currently available in Rust without
-/// consideration for cryptography or security. If you require a specifically
-/// seeded `Rng` for consistency over time you should pick one algorithm and
-/// create the `Rng` yourself.
-///
-/// This will read randomness from the operating system to seed the
-/// generator.
-pub fn weak_rng() -> XorShiftRng {
-    match OsRng::new() {
-        Ok(mut r) => r.gen(),
-        Err(e) => panic!("weak_rng: failed to create seeded RNG: {:?}", e)
-    }
-}
-
 /// Controls how the thread-local RNG is reseeded.
 struct ThreadRngReseeder;
 
@@ -910,7 +894,7 @@ mod test {
     }
 
     pub fn weak_rng() -> MyRng<::XorShiftRng> {
-        MyRng { inner: ::weak_rng() }
+        MyRng { inner: random() }
     }
 
     struct ConstRng { i: u64 }
@@ -1106,8 +1090,7 @@ static RAND_BENCH_N: u64 = 100;
 mod bench {
     extern crate test;
     use self::test::Bencher;
-    use super::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N};
-    use super::{OsRng, weak_rng};
+    use super::{random, XorShiftRng, StdRng, IsaacRng, Isaac64Rng, OsRng, Rng, RAND_BENCH_N};
     use std::mem::size_of;
 
     #[bench]
@@ -1156,7 +1139,7 @@ mod bench {
 
     #[bench]
     fn rand_shuffle_100(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         let x : &mut[uint] = &mut [1; 100];
         b.iter(|| {
             rng.shuffle(x);


### PR DESCRIPTION
Documentation for the function claims it will return the fastest algorithm
available in Rust, but since its return type is hardcoded to XorShiftRng, it
would be an impossible [breaking-change], when, or if, a faster Rng is added to
Rust.

[breaking-change], since this removes public API. Uses of `weak_rng` function
can be replaced with `random::<XorShiftRng>()` to achieve almost the same
behaviour.

This is https://github.com/rust-lang/rust/pull/20773.