### PR TITLE
Cleanup int and uint

### DIFF
--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -14,9 +14,9 @@ use core::prelude::*;
 use core::num::Int;
 use {Rng, SeedableRng, Rand};
 
-const KEY_WORDS    : uint =  8; // 8 words for the 256-bit key
-const STATE_WORDS  : uint = 16;
-const CHACHA_ROUNDS: uint = 20; // Cryptographically secure from 8 upwards as of this writing
+const KEY_WORDS    : usize =  8; // 8 words for the 256-bit key
+const STATE_WORDS  : usize = 16;
+const CHACHA_ROUNDS: usize = 20; // Cryptographically secure from 8 upwards as of this writing
 
 /// A random number generator that uses the ChaCha20 algorithm [1].
 ///
@@ -31,7 +31,7 @@ const CHACHA_ROUNDS: uint = 20; // Cryptographically secure from 8 upwards as of
 pub struct ChaChaRng {
     buffer:  [u32; STATE_WORDS], // Internal buffer of output
     state:   [u32; STATE_WORDS], // Initial state
-    index:   uint,                 // Index into state
+    index:   usize,                 // Index into state
 }
 
 static EMPTY: ChaChaRng = ChaChaRng {
@@ -268,9 +268,9 @@ mod test {
         // Store the 17*i-th 32-bit word,
         // i.e., the i-th word of the i-th 16-word block
         let mut v : Vec<u32> = Vec::new();
-        for _ in 0u..16 {
+        for _ in 0..16 {
             v.push(ra.next_u32());
-            for _ in 0u..16 {
+            for _ in 0..16 {
                 ra.next_u32();
             }
         }
@@ -287,7 +287,7 @@ mod test {
         let seed : &[_] = &[0u32; 8];
         let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
         let mut clone = rng.clone();
-        for _ in 0u..16 {
+        for _ in 0..16 {
             assert_eq!(rng.next_u64(), clone.next_u64());
         }
     }

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -100,7 +100,7 @@ mod test {
     fn test_exp() {
         let mut exp = Exp::new(10.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             assert!(exp.sample(&mut rng) >= 0.0);
             assert!(exp.ind_sample(&mut rng) >= 0.0);
         }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -326,7 +326,7 @@ mod test {
     fn test_chi_squared_one() {
         let mut chi = ChiSquared::new(1.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
         }
@@ -335,7 +335,7 @@ mod test {
     fn test_chi_squared_small() {
         let mut chi = ChiSquared::new(0.5);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
         }
@@ -344,7 +344,7 @@ mod test {
     fn test_chi_squared_large() {
         let mut chi = ChiSquared::new(30.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
         }
@@ -359,7 +359,7 @@ mod test {
     fn test_f() {
         let mut f = FisherF::new(2.0, 32.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             f.sample(&mut rng);
             f.ind_sample(&mut rng);
         }
@@ -369,7 +369,7 @@ mod test {
     fn test_t() {
         let mut t = StudentT::new(11.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             t.sample(&mut rng);
             t.ind_sample(&mut rng);
         }

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -165,7 +165,7 @@ mod tests {
     fn test_normal() {
         let mut norm = Normal::new(10.0, 10.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             norm.sample(&mut rng);
             norm.ind_sample(&mut rng);
         }
@@ -181,7 +181,7 @@ mod tests {
     fn test_log_normal() {
         let mut lnorm = LogNormal::new(10.0, 10.0);
         let mut rng = ::test::rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             lnorm.sample(&mut rng);
             lnorm.ind_sample(&mut rng);
         }

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -38,10 +38,10 @@ use distributions::{Sample, IndependentSample};
 /// use rand::distributions::{IndependentSample, Range};
 ///
 /// fn main() {
-///     let between = Range::new(10u, 10000u);
+///     let between = Range::new(10, 10000);
 ///     let mut rng = rand::thread_rng();
 ///     let mut sum = 0;
-///     for _ in 0u..1000 {
+///     for _ in 0..1000 {
 ///         sum += between.ind_sample(&mut rng);
 ///     }
 ///     println!("{}", sum);
@@ -134,12 +134,12 @@ integer_impl! { i8, u8 }
 integer_impl! { i16, u16 }
 integer_impl! { i32, u32 }
 integer_impl! { i64, u64 }
-integer_impl! { int, uint }
+integer_impl! { isize, usize }
 integer_impl! { u8, u8 }
 integer_impl! { u16, u16 }
 integer_impl! { u32, u32 }
 integer_impl! { u64, u64 }
-integer_impl! { uint, uint }
+integer_impl! { usize, usize }
 
 macro_rules! float_impl {
     ($ty:ty) => {
@@ -190,7 +190,7 @@ mod tests {
                                             (Int::min_value(), Int::max_value())];
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
-                        for _ in 0u..1000 {
+                        for _ in 0..1000 {
                             let v = sampler.sample(&mut rng);
                             assert!(low <= v && v < high);
                             let v = sampler.ind_sample(&mut rng);
@@ -200,8 +200,8 @@ mod tests {
                  )*
             }}
         }
-        t!(i8, i16, i32, i64, int,
-           u8, u16, u32, u64, uint)
+        t!(i8, i16, i32, i64, isize,
+           u8, u16, u32, u64, usize)
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
                                             (-1e35, 1e35)];
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
-                        for _ in 0u..1000 {
+                        for _ in 0..1000 {
                             let v = sampler.sample(&mut rng);
                             assert!(low <= v && v < high);
                             let v = sampler.ind_sample(&mut rng);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!
 //! let mut rng = rand::thread_rng();
 //! if rng.gen() { // random bool
-//!     println!("int: {}, uint: {}", rng.gen::<int>(), rng.gen::<uint>())
+//!     println!("i32: {}, u32: {}", rng.gen::<i32>(), rng.gen::<u32>())
 //! }
 //! ```
 //!
@@ -98,7 +98,7 @@
 //!    let total = 1_000_000;
 //!    let mut in_circle = 0;
 //!
-//!    for _ in 0u..total {
+//!    for _ in 0..total {
 //!        let a = between.ind_sample(&mut rng);
 //!        let b = between.ind_sample(&mut rng);
 //!        if a*a + b*b <= 1. {
@@ -139,7 +139,7 @@
 //! }
 //!
 //! // Run a single simulation of the Monty Hall problem.
-//! fn simulate<R: Rng>(random_door: &Range<uint>, rng: &mut R) -> SimulationResult {
+//! fn simulate<R: Rng>(random_door: &Range<usize>, rng: &mut R) -> SimulationResult {
 //!     let car = random_door.ind_sample(rng);
 //!
 //!     // This is our initial choice
@@ -159,19 +159,19 @@
 //!
 //! // Returns the door the game host opens given our choice and knowledge of
 //! // where the car is. The game host will never open the door with the car.
-//! fn game_host_open<R: Rng>(car: uint, choice: uint, rng: &mut R) -> uint {
+//! fn game_host_open<R: Rng>(car: usize, choice: usize, rng: &mut R) -> usize {
 //!     let choices = free_doors(&[car, choice]);
 //!     rand::sample(rng, choices.into_iter(), 1)[0]
 //! }
 //!
 //! // Returns the door we switch to, given our current choice and
 //! // the open door. There will only be one valid door.
-//! fn switch_door(choice: uint, open: uint) -> uint {
+//! fn switch_door(choice: usize, open: usize) -> usize {
 //!     free_doors(&[choice, open])[0]
 //! }
 //!
-//! fn free_doors(blocked: &[uint]) -> Vec<uint> {
-//!     (0u..3).filter(|x| !blocked.contains(x)).collect()
+//! fn free_doors(blocked: &[usize]) -> Vec<usize> {
+//!     (0..3).filter(|x| !blocked.contains(x)).collect()
 //! }
 //!
 //! fn main() {
@@ -217,7 +217,6 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/rand/")]
-#![feature(int_uint)]
 #![feature(core, os, libc, path, io)]
 
 #![cfg_attr(test, feature(test, std_misc))]
@@ -288,8 +287,8 @@ pub trait Rng : Sized {
     /// See `Closed01` for the closed interval `[0,1]`, and
     /// `Open01` for the open interval `(0,1)`.
     fn next_f32(&mut self) -> f32 {
-        const MANTISSA_BITS: uint = 24;
-        const IGNORED_BITS: uint = 8;
+        const MANTISSA_BITS: usize = 24;
+        const IGNORED_BITS: usize = 8;
         const SCALE: f32 = (1u64 << MANTISSA_BITS) as f32;
 
         // using any more than `MANTISSA_BITS` bits will
@@ -310,8 +309,8 @@ pub trait Rng : Sized {
     /// See `Closed01` for the closed interval `[0,1]`, and
     /// `Open01` for the open interval `(0,1)`.
     fn next_f64(&mut self) -> f64 {
-        const MANTISSA_BITS: uint = 53;
-        const IGNORED_BITS: uint = 11;
+        const MANTISSA_BITS: usize = 53;
+        const IGNORED_BITS: usize = 11;
         const SCALE: f64 = (1u64 << MANTISSA_BITS) as f64;
 
         (self.next_u64() >> IGNORED_BITS) as f64 / SCALE
@@ -376,7 +375,7 @@ pub trait Rng : Sized {
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
-    /// let x: uint = rng.gen();
+    /// let x: u32 = rng.gen();
     /// println!("{}", x);
     /// println!("{:?}", rng.gen::<(f64, bool)>());
     /// ```
@@ -394,7 +393,7 @@ pub trait Rng : Sized {
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
-    /// let x = rng.gen_iter::<uint>().take(10).collect::<Vec<uint>>();
+    /// let x = rng.gen_iter::<u32>().take(10).collect::<Vec<u32>>();
     /// println!("{:?}", x);
     /// println!("{:?}", rng.gen_iter::<(f64, bool)>().take(5)
     ///                     .collect::<Vec<(f64, bool)>>());
@@ -421,7 +420,7 @@ pub trait Rng : Sized {
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
-    /// let n: uint = rng.gen_range(0u, 10);
+    /// let n: u32 = rng.gen_range(0, 10);
     /// println!("{}", n);
     /// let m: f64 = rng.gen_range(-40.0f64, 1.3e5f64);
     /// println!("{}", m);
@@ -441,7 +440,7 @@ pub trait Rng : Sized {
     /// let mut rng = thread_rng();
     /// println!("{}", rng.gen_weighted_bool(3));
     /// ```
-    fn gen_weighted_bool(&mut self, n: uint) -> bool {
+    fn gen_weighted_bool(&mut self, n: usize) -> bool {
         n <= 1 || self.gen_range(0, n) == 0
     }
 
@@ -477,7 +476,7 @@ pub trait Rng : Sized {
         if values.is_empty() {
             None
         } else {
-            Some(&values[self.gen_range(0u, values.len())])
+            Some(&values[self.gen_range(0, values.len())])
         }
     }
 
@@ -497,11 +496,11 @@ pub trait Rng : Sized {
     /// ```
     fn shuffle<T>(&mut self, values: &mut [T]) {
         let mut i = values.len();
-        while i >= 2u {
+        while i >= 2 {
             // invariant: elements with index >= i have been locked in place.
-            i -= 1u;
+            i -= 1;
             // lock element i in place.
-            values.swap(i, self.gen_range(0u, i + 1u));
+            values.swap(i, self.gen_range(0, i + 1));
         }
     }
 }
@@ -778,7 +777,7 @@ pub struct ThreadRng {
 
 /// Retrieve the lazily-initialized thread-local random number
 /// generator, seeded by the system. Intended to be used in method
-/// chaining style, e.g. `thread_rng().gen::<int>()`.
+/// chaining style, e.g. `thread_rng().gen::<i32>()`.
 ///
 /// The RNG provided will reseed itself from the operating system
 /// after generating a certain amount of randomness.
@@ -944,14 +943,14 @@ mod test {
     #[test]
     fn test_gen_range() {
         let mut r = thread_rng();
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             let a = r.gen_range(-3, 42);
             assert!(a >= -3 && a < 42);
             assert_eq!(r.gen_range(0, 1), 0);
             assert_eq!(r.gen_range(-12, -11), -12);
         }
 
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             let a = r.gen_range(10, 42);
             assert!(a >= 10 && a < 42);
             assert_eq!(r.gen_range(0, 1), 0);
@@ -969,7 +968,7 @@ mod test {
 
     #[test]
     #[should_fail]
-    fn test_gen_range_panic_uint() {
+    fn test_gen_range_panic_usize() {
         let mut r = thread_rng();
         r.gen_range(5us, 2us);
     }
@@ -1010,14 +1009,14 @@ mod test {
         let mut r = thread_rng();
         assert_eq!(r.choose(&[1, 1, 1]).map(|&x|x), Some(1));
 
-        let v: &[int] = &[];
+        let v: &[isize] = &[];
         assert_eq!(r.choose(v), None);
     }
 
     #[test]
     fn test_shuffle() {
         let mut r = thread_rng();
-        let empty: &mut [int] = &mut [];
+        let empty: &mut [isize] = &mut [];
         r.shuffle(empty);
         let mut one = [1];
         r.shuffle(&mut one);
@@ -1037,7 +1036,7 @@ mod test {
     #[test]
     fn test_thread_rng() {
         let mut r = thread_rng();
-        r.gen::<int>();
+        r.gen::<i32>();
         let mut v = [1, 1, 1];
         r.shuffle(&mut v);
         let b: &[_] = &[1, 1, 1];
@@ -1048,12 +1047,12 @@ mod test {
     #[test]
     fn test_random() {
         // not sure how to test this aside from just getting some values
-        let _n : uint = random();
+        let _n : usize = random();
         let _f : f32 = random();
         let _o : Option<Option<i8>> = random();
         let _many : ((),
-                     (uint,
-                      int,
+                     (usize,
+                      isize,
                       Option<(u32, (bool,))>),
                      (u8, i8, u16, i16, u32, i32, u64, i64),
                      (f32, (f64, (f64,)))) = random();
@@ -1065,7 +1064,7 @@ mod test {
         let max_val = 100;
 
         let mut r = thread_rng();
-        let vals = (min_val..max_val).collect::<Vec<int>>();
+        let vals = (min_val..max_val).collect::<Vec<i32>>();
         let small_sample = sample(&mut r, vals.iter(), 5);
         let large_sample = sample(&mut r, vals.iter(), vals.len() + 5);
 
@@ -1079,7 +1078,7 @@ mod test {
 
     #[test]
     fn test_std_rng_seeded() {
-        let s = thread_rng().gen_iter::<uint>().take(256).collect::<Vec<uint>>();
+        let s = thread_rng().gen_iter::<usize>().take(256).collect::<Vec<usize>>();
         let mut ra: StdRng = SeedableRng::from_seed(s.as_slice());
         let mut rb: StdRng = SeedableRng::from_seed(s.as_slice());
         assert!(order::equals(ra.gen_ascii_chars().take(100),
@@ -1088,7 +1087,7 @@ mod test {
 
     #[test]
     fn test_std_rng_reseed() {
-        let s = thread_rng().gen_iter::<uint>().take(256).collect::<Vec<uint>>();
+        let s = thread_rng().gen_iter::<usize>().take(256).collect::<Vec<usize>>();
         let mut r: StdRng = SeedableRng::from_seed(s.as_slice());
         let string1 = r.gen_ascii_chars().take(100).collect::<String>();
 
@@ -1115,10 +1114,10 @@ mod bench {
         let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
         b.iter(|| {
             for _ in 0..RAND_BENCH_N {
-                rng.gen::<uint>();
+                rng.gen::<usize>();
             }
         });
-        b.bytes = size_of::<uint>() as u64 * RAND_BENCH_N;
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
     }
 
     #[bench]
@@ -1126,10 +1125,10 @@ mod bench {
         let mut rng: IsaacRng = OsRng::new().unwrap().gen();
         b.iter(|| {
             for _ in 0..RAND_BENCH_N {
-                rng.gen::<uint>();
+                rng.gen::<usize>();
             }
         });
-        b.bytes = size_of::<uint>() as u64 * RAND_BENCH_N;
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
     }
 
     #[bench]
@@ -1137,10 +1136,10 @@ mod bench {
         let mut rng: Isaac64Rng = OsRng::new().unwrap().gen();
         b.iter(|| {
             for _ in 0..RAND_BENCH_N {
-                rng.gen::<uint>();
+                rng.gen::<usize>();
             }
         });
-        b.bytes = size_of::<uint>() as u64 * RAND_BENCH_N;
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
     }
 
     #[bench]
@@ -1148,10 +1147,10 @@ mod bench {
         let mut rng = StdRng::new().unwrap();
         b.iter(|| {
             for _ in 0..RAND_BENCH_N {
-                rng.gen::<uint>();
+                rng.gen::<usize>();
             }
         });
-        b.bytes = size_of::<uint>() as u64 * RAND_BENCH_N;
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
     }
 
     #[bench]

--- a/src/os.rs
+++ b/src/os.rs
@@ -369,7 +369,7 @@ mod test {
     fn test_os_rng_tasks() {
 
         let mut txs = vec!();
-        for _ in 0u..20 {
+        for _ in 0..20 {
             let (tx, rx) = channel();
             txs.push(tx);
 
@@ -383,7 +383,7 @@ mod test {
                 Thread::yield_now();
                 let mut v = [0u8; 1000];
 
-                for _ in 0u..100 {
+                for _ in 0..100 {
                     r.next_u32();
                     Thread::yield_now();
                     r.next_u64();

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -12,18 +12,18 @@
 
 use core::prelude::*;
 use core::char;
-use core::int;
-use core::uint;
+use core::isize;
+use core::usize;
 
 use {Rand,Rng};
 
-impl Rand for int {
+impl Rand for isize {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> int {
-        if int::BITS == 32 {
-            rng.gen::<i32>() as int
+    fn rand<R: Rng>(rng: &mut R) -> isize {
+        if isize::BITS == 32 {
+            rng.gen::<i32>() as isize
         } else {
-            rng.gen::<i64>() as int
+            rng.gen::<i64>() as isize
         }
     }
 }
@@ -56,13 +56,13 @@ impl Rand for i64 {
     }
 }
 
-impl Rand for uint {
+impl Rand for usize {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> uint {
-        if uint::BITS == 32 {
-            rng.gen::<u32>() as uint
+    fn rand<R: Rng>(rng: &mut R) -> usize {
+        if usize::BITS == 32 {
+            rng.gen::<u32>() as usize
         } else {
-            rng.gen::<u64>() as uint
+            rng.gen::<u64>() as usize
         }
     }
 }
@@ -240,7 +240,7 @@ mod tests {
         // this is unlikely to catch an incorrect implementation that
         // generates exactly 0 or 1, but it keeps it sane.
         let mut rng = thread_rng();
-        for _ in 0u..1_000 {
+        for _ in 0..1_000 {
             // strict inequalities
             let Open01(f) = rng.gen::<Open01<f64>>();
             assert!(0.0 < f && f < 1.0);
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn rand_closed() {
         let mut rng = thread_rng();
-        for _ in 0u..1_000 {
+        for _ in 0..1_000 {
             // strict inequalities
             let Closed01(f) = rng.gen::<Closed01<f64>>();
             assert!(0.0 <= f && f <= 1.0);

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -18,14 +18,14 @@ use core::default::Default;
 
 /// How many bytes of entropy the underling RNG is allowed to generate
 /// before it is reseeded.
-static DEFAULT_GENERATION_THRESHOLD: uint = 32 * 1024;
+static DEFAULT_GENERATION_THRESHOLD: usize = 32 * 1024;
 
 /// A wrapper around any RNG which reseeds the underlying RNG after it
 /// has generated a certain number of random bytes.
 pub struct ReseedingRng<R, Rsdr> {
     rng: R,
-    generation_threshold: uint,
-    bytes_generated: uint,
+    generation_threshold: usize,
+    bytes_generated: usize,
     /// Controls the behaviour when reseeding the RNG.
     pub reseeder: Rsdr,
 }
@@ -38,7 +38,7 @@ impl<R: Rng, Rsdr: Reseeder<R>> ReseedingRng<R, Rsdr> {
     /// * `rng`: the random number generator to use.
     /// * `generation_threshold`: the number of bytes of entropy at which to reseed the RNG.
     /// * `reseeder`: the reseeding object to use.
-    pub fn new(rng: R, generation_threshold: uint, reseeder: Rsdr) -> ReseedingRng<R,Rsdr> {
+    pub fn new(rng: R, generation_threshold: usize, reseeder: Rsdr) -> ReseedingRng<R,Rsdr> {
         ReseedingRng {
             rng: rng,
             generation_threshold: generation_threshold,
@@ -187,7 +187,7 @@ mod test {
         let mut rs = ReseedingRng::new(Counter {i:0}, 400, ReseedWithDefault);
 
         let mut i = 0;
-        for _ in 0u..1000 {
+        for _ in 0..1000 {
             assert_eq!(rs.next_u32(), i % 100);
             i += 1;
         }
@@ -212,7 +212,7 @@ mod test {
         assert_eq!(string1, string2);
     }
 
-    static FILL_BYTES_V_LEN: uint = 13579;
+    static FILL_BYTES_V_LEN: usize = 13579;
     #[test]
     fn test_rng_fill_bytes() {
         let mut v = repeat(0u8).take(FILL_BYTES_V_LEN).collect::<Vec<_>>();


### PR DESCRIPTION
Removes most of the `uint` and `int` occurences. One occurence of uint in `src/lib.rs` is left unchanged intentionally so the PR doesn’t conflict with #3.