### PR TITLE
Range syntax distribution

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -18,10 +18,10 @@
 //! that do not need to record state.
 use core::prelude::*;
 use core::num::{Float, Int};
+use std::ops::Range;
 
 use {Rng, Rand};
 
-pub use self::range::Range;
 pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
 pub use self::normal::{Normal, LogNormal};
 pub use self::exponential::Exp;
@@ -134,7 +134,7 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
             items: items,
             // we're likely to be generating numbers in this range
             // relatively often, so might as well cache it
-            weight_range: Range::new(0, running_total)
+            weight_range: 0..running_total
         }
     }
 }

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -199,3 +199,38 @@ mod tests {
     }
 
 }
+
+#[cfg(test)]
+mod bench {
+    extern crate test;
+    use std::prelude::v1::*;
+    use self::test::Bencher;
+    use std::mem::size_of;
+    use distributions::IndependentSample;
+
+    #[bench]
+    fn rand_float(b: &mut Bencher) {
+        let mut rng = ::test::weak_rng();
+        let range = -2.71828..3.14159;
+
+        b.iter(|| {
+            for _ in 0..::RAND_BENCH_N {
+                range.ind_sample(&mut rng);
+            }
+        });
+        b.bytes = size_of::<f64>() as u64 * ::RAND_BENCH_N;
+    }
+
+    #[bench]
+    fn rand_int(b: &mut Bencher) {
+        let mut rng = ::test::weak_rng();
+        let range = -99..6418i32;
+
+        b.iter(|| {
+            for _ in 0..::RAND_BENCH_N {
+                range.ind_sample(&mut rng);
+            }
+        });
+        b.bytes = size_of::<f64>() as u64 * ::RAND_BENCH_N;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,10 @@
 //! multiply this fraction by 4.
 //!
 //! ```
-//! use rand::distributions::{IndependentSample, Range};
+//! use rand::distributions::IndependentSample;
 //!
 //! fn main() {
-//!    let between = Range::new(-1f64, 1.);
+//!    let between = -1f64..1.;
 //!    let mut rng = rand::thread_rng();
 //!
 //!    let total = 1_000_000;
@@ -131,7 +131,8 @@
 //!
 //! ```
 //! use rand::Rng;
-//! use rand::distributions::{IndependentSample, Range};
+//! use rand::distributions::IndependentSample;
+//! use std::ops::Range;
 //!
 //! struct SimulationResult {
 //!     win: bool,
@@ -179,7 +180,7 @@
 //!     let num_simulations = 10000;
 //!
 //!     let mut rng = rand::thread_rng();
-//!     let random_door = Range::new(0, 3);
+//!     let random_door = 0..3;
 //!
 //!     let (mut switch_wins, mut switch_losses) = (0, 0);
 //!     let (mut keep_wins, mut keep_losses) = (0, 0);
@@ -239,7 +240,7 @@ use IsaacRng as IsaacWordRng;
 #[cfg(target_pointer_width = "64")]
 use Isaac64Rng as IsaacWordRng;
 
-use distributions::{Range, IndependentSample};
+use distributions::IndependentSample;
 use distributions::range::SampleRange;
 
 pub mod distributions;
@@ -404,11 +405,7 @@ pub trait Rng : Sized {
 
     /// Generate a random value in the range [`low`, `high`).
     ///
-    /// This is a convenience wrapper around
-    /// `distributions::Range`. If this function will be called
-    /// repeatedly with the same arguments, one should use `Range`, as
-    /// that will amortize the computations that allow for perfect
-    /// uniformity, as they only happen on initialization.
+    /// This is a convenience function
     ///
     /// # Panics
     ///
@@ -426,8 +423,7 @@ pub trait Rng : Sized {
     /// println!("{}", m);
     /// ```
     fn gen_range<T: PartialOrd + SampleRange>(&mut self, low: T, high: T) -> T {
-        assert!(low < high, "Rng.gen_range called with low >= high");
-        Range::new(low, high).ind_sample(self)
+        (low..high).ind_sample(self)
     }
 
     /// Return a bool with a 1 in n chance of true


### PR DESCRIPTION
removed the `Range` type and uses the range syntax instead.

Yes, picking out single random numbers is slower than before. The subtraction and modulo are done "every" time. Inlining and optimizations should kill them in most cases. Also generating random numbers is some powers slower than the subtract and mod.

benchmarks with PR
```
test bench::rand_isaac                                    ... bench:       651 ns/iter (+/- 52) = 1228 MB/s
test bench::rand_isaac64                                  ... bench:       358 ns/iter (+/- 24) = 2234 MB/s
test bench::rand_shuffle_100                              ... bench:      1661 ns/iter (+/- 130)
test bench::rand_std                                      ... bench:       379 ns/iter (+/- 14) = 2110 MB/s
test bench::rand_xorshift                                 ... bench:         0 ns/iter (+/- 0) = 800000 MB/s
test distributions::exponential::bench::rand_exp          ... bench:       868 ns/iter (+/- 42) = 921 MB/s
test distributions::gamma::bench::bench_gamma_large_shape ... bench:      2214 ns/iter (+/- 158) = 361 MB/s
test distributions::gamma::bench::bench_gamma_small_shape ... bench:      2421 ns/iter (+/- 41) = 330 MB/s
test distributions::normal::bench::rand_normal            ... bench:       612 ns/iter (+/- 53) = 1307 MB/s
test distributions::range::bench::rand_float              ... bench:       183 ns/iter (+/- 12) = 4371 MB/s
test distributions::range::bench::rand_int                ... bench:       148 ns/iter (+/- 3) = 5405 MB/s
```

benchmarks w/o PR (but added the same benchmark code)
```
test bench::rand_isaac                                    ... bench:       635 ns/iter (+/- 42) = 1259 MB/s
test bench::rand_isaac64                                  ... bench:       358 ns/iter (+/- 24) = 2234 MB/s
test bench::rand_shuffle_100                              ... bench:      1661 ns/iter (+/- 131)
test bench::rand_std                                      ... bench:       366 ns/iter (+/- 19) = 2185 MB/s
test bench::rand_xorshift                                 ... bench:         0 ns/iter (+/- 0) = 800000 MB/s
test distributions::exponential::bench::rand_exp          ... bench:       836 ns/iter (+/- 118) = 956 MB/s
test distributions::gamma::bench::bench_gamma_large_shape ... bench:      2166 ns/iter (+/- 149) = 369 MB/s
test distributions::gamma::bench::bench_gamma_small_shape ... bench:      2411 ns/iter (+/- 94) = 331 MB/s
test distributions::normal::bench::rand_normal            ... bench:       609 ns/iter (+/- 51) = 1313 MB/s
test distributions::range::bench::rand_float              ... bench:       183 ns/iter (+/- 15) = 4371 MB/s
test distributions::range::bench::rand_int                ... bench:       150 ns/iter (+/- 6) = 5333 MB/s
```