### PR TITLE
Update to use latest log version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ Random number generators and other randomness functionality.
 keywords = ["random"]
 
 [dependencies]
-log = "0.2.1"
+log = "0.3.0"
 libc = "0.1.1"
 
 [dev-dependencies.rand_macros]


### PR DESCRIPTION
This was causing "multiple rlib candidates" errors when linking in a project
that also depended on a more recent log version.