### PR TITLE
Needed #![feature(os)] for last_os_error()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/rand/")]
-#![feature(core, io, step_by)]
+#![feature(core, io, step_by, os)]
 
 #![cfg_attr(test, feature(test))]
 


### PR DESCRIPTION
std::os is deprecated in favour of std::env, but wasn't sure where else to get last_os_error()