### PR TITLE
Implement Clone trait for Weighted

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -365,6 +365,31 @@ mod tests {
            [50, 51, 52, 53, 54, 55, 56]);
     }
 
+    #[test]
+    fn test_weighted_clone_initialization() {
+        let initial : Weighted<u32> = Weighted {weight: 1, item: 1};
+        let mut clone = initial.clone();
+        assert_eq!(initial.weight, clone.weight);
+        assert_eq!(initial.item, clone.item);
+    }
+
+    #[test] #[should_panic]
+    fn test_weighted_clone_change_weight() {
+        let initial : Weighted<u32> = Weighted {weight: 1, item: 1};
+        let mut clone = initial.clone();
+        clone.weight = 5;
+        assert_eq!(initial.weight, clone.weight);
+    }
+
+    #[test] #[should_panic]
+    fn test_weighted_clone_change_item() {
+        let initial : Weighted<u32> = Weighted {weight: 1, item: 1};
+        let mut clone = initial.clone();
+        clone.item = 5;
+        assert_eq!(initial.item, clone.item);
+
+    }
+
     #[test] #[should_panic]
     fn test_weighted_choice_no_items() {
         WeightedChoice::<isize>::new(&mut []);

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -85,6 +85,20 @@ pub struct Weighted<T> {
     pub item: T,
 }
 
+//implementation of Clone for Weighted
+impl<T> Clone for Weighted<T> where T:Clone{
+    fn clone(&self) -> Self {
+        Weighted {
+            weight: self.weight.clone(),
+            item: self.item.clone()
+        }
+    }
+    fn clone_from(&mut self, source: &Self) {
+        self.weight = source.weight.clone();
+        self.item = source.item.clone();
+    }
+}
+
 /// A distribution that selects from a finite collection of weighted items.
 ///
 /// Each item has an associated weight that influences how likely it

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -78,25 +78,12 @@ impl<Sup> RandSample<Sup> {
 
 /// A value with a particular weight for use with `WeightedChoice`.
 #[derive(Copy)]
+#[derive(Clone)]
 pub struct Weighted<T> {
     /// The numerical weight of this item
     pub weight: u32,
     /// The actual item which is being weighted
     pub item: T,
-}
-
-//implementation of Clone for Weighted
-impl<T> Clone for Weighted<T> where T:Clone{
-    fn clone(&self) -> Self {
-        Weighted {
-            weight: self.weight.clone(),
-            item: self.item.clone()
-        }
-    }
-    fn clone_from(&mut self, source: &Self) {
-        self.weight = source.weight.clone();
-        self.item = source.item.clone();
-    }
 }
 
 /// A distribution that selects from a finite collection of weighted items.


### PR DESCRIPTION
Since WeightedChoice demands an &mut reference into a mutable slice of Weighted, thus mutating whatever list one passes in, Weighted should implement Clone so that users can clone any Vec they are using to pass to WeightedChoice if so desired.