### PR TITLE
Fixups for recent Rust changes

### DIFF
--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -10,7 +10,6 @@
 
 //! The ChaCha random number generator.
 
-use std::num::Int;
 use std::num::Wrapping as w;
 use {Rng, SeedableRng, Rand, w32};
 

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -11,7 +11,7 @@
 //! The ChaCha random number generator.
 
 use std::num::Int;
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 use {Rng, SeedableRng, Rand, w32};
 
 const KEY_WORDS    : usize =  8; // 8 words for the 256-bit key

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -10,8 +10,6 @@
 
 //! The exponential distribution.
 
-use std::num::Float;
-
 use {Rng, Rand};
 use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -15,8 +15,6 @@
 use self::GammaRepr::*;
 use self::ChiSquaredRepr::*;
 
-use std::num::Float;
-
 use {Rng, Open01};
 use super::normal::StandardNormal;
 use super::{IndependentSample, Sample, Exp};

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -10,8 +10,6 @@
 
 //! The normal and derived distributions.
 
-use std::num::Float;
-
 use {Rng, Rand, Open01};
 use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -13,7 +13,7 @@
 // this is surprisingly complicated to be both generic & correct
 
 use std::num::Int;
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 
 use Rng;
 use distributions::{Sample, IndependentSample};

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -12,7 +12,6 @@
 
 // this is surprisingly complicated to be both generic & correct
 
-use std::num::Int;
 use std::num::Wrapping as w;
 
 use Rng;
@@ -99,7 +98,7 @@ macro_rules! integer_impl {
 
             fn construct_range(low: $ty, high: $ty) -> Range<$ty> {
                 let range = (w(high as $unsigned) - w(low as $unsigned)).0;
-                let unsigned_max: $unsigned = Int::max_value();
+                let unsigned_max: $unsigned = -1 as $unsigned;
 
                 // this is the largest number that fits into $unsigned
                 // that `range` divides evenly, so, if we've sampled

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -14,7 +14,7 @@
 
 use std::slice;
 use std::iter::repeat;
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 
 use {Rng, SeedableRng, Rand, w32, w64};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ use std::marker;
 use std::mem;
 use std::io;
 use std::rc::Rc;
-use std::num::wrapping::Wrapping as w;
+use std::num::Wrapping as w;
 
 pub use os::OsRng;
 


### PR DESCRIPTION
* Use Wrapping is its new home in std::num.
* Stop using the Int and Float traits. This involves no longer using Int::max_value().