### PR TITLE
Update for stabilized io::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,9 +224,9 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/rand/")]
-#![feature(core, io, step_by)]
+#![feature(step_by)]
 
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core, test))]
 
 #[cfg(test)] #[macro_use] extern crate log;
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -68,7 +68,7 @@ fn fill(r: &mut Read, mut buf: &mut [u8]) -> io::Result<()> {
     while buf.len() > 0 {
         match try!(r.read(buf)) {
             0 => return Err(io::Error::new(io::ErrorKind::Other,
-                                           "end of file reached", None)),
+                                           "end of file reached")),
             n => buf = &mut mem::replace(&mut buf, &mut [])[n..],
         }
     }


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/pull/23919, the last argument was removed from `Error::new`.