### PR TITLE
Update rand_macros for changes to register_syntax_extension

### DIFF
--- a/rand_macros/src/lib.rs
+++ b/rand_macros/src/lib.rs
@@ -37,7 +37,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 pub fn expand_deriving_rand(cx: &mut ExtCtxt,
                             span: Span,
                             mitem: &MetaItem,
-                            item: Annotatable,
+                            item: &Annotatable,
                             push: &mut FnMut(Annotatable)) {
     let trait_def = TraitDef {
         span: span,


### PR DESCRIPTION
Update rand_macros for changes to register_syntax_extension.

This brings it up to date with the latest nightly.