### PR TITLE
Add Sized to SampleRange

### DIFF
--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -75,7 +75,7 @@ impl<Sup: SampleRange> IndependentSample<Sup> for Range<Sup> {
 /// The helper trait for types that have a sensible way to sample
 /// uniformly between two values. This should not be used directly,
 /// and is only to facilitate `Range`.
-pub trait SampleRange {
+pub trait SampleRange : Sized {
     /// Construct the `Range` object that `sample_range`
     /// requires. This should not ever be called directly, only via
     /// `Range::new`, which will check that `low < high`, so this


### PR DESCRIPTION
Add Sized to SampleRange

Fix SampleRange for well-formedness warnings on nightly.
See Rust RFC 1214.

This change mirrors the corresponding change in the rust tree.