### PR TITLE
Implement Rand for arrays with n <= 32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - 1.0.0
+  - stable
   - beta
   - nightly
 sudo: false

--- a/rand_macros/src/lib.rs
+++ b/rand_macros/src/lib.rs
@@ -45,6 +45,7 @@ pub fn expand_deriving_rand(cx: &mut ExtCtxt,
         path: Path::new(vec!("rand", "Rand")),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
+        is_unsafe: false,
         methods: vec!(
             MethodDef {
                 name: "rand",

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -200,8 +200,8 @@ tuple_impl!{A, B, C, D, E, F, G, H, I, J, K}
 tuple_impl!{A, B, C, D, E, F, G, H, I, J, K, L}
 
 macro_rules! array_impl {
-    {$n:expr, $t:ident $($ts:ident)*} => {
-        array_impl!{($n - 1), $($ts)*}
+    {$n:expr, $t:ident, $($ts:ident,)*} => {
+        array_impl!{($n - 1), $($ts,)*}
 
         impl<T> Rand for [T; $n] where T: Rand {
             #[inline]
@@ -217,7 +217,7 @@ macro_rules! array_impl {
     };
 }
 
-array_impl!{32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
+array_impl!{32, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,}
 
 impl<T:Rand> Rand for Option<T> {
     #[inline]

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -199,6 +199,26 @@ tuple_impl!{A, B, C, D, E, F, G, H, I, J}
 tuple_impl!{A, B, C, D, E, F, G, H, I, J, K}
 tuple_impl!{A, B, C, D, E, F, G, H, I, J, K, L}
 
+macro_rules! array_impl {
+    {$n:expr, $t:ident $($ts:ident)*} => {
+        array_impl!{($n - 1), $($ts)*}
+
+        impl<T> Rand for [T; $n] where T: Rand {
+            #[inline]
+            fn rand<R: Rng>(_rng: &mut R) -> [T; $n] {
+                [_rng.gen::<$t>(), $(_rng.gen::<$ts>()),*]
+            }
+        }
+    };
+    {$n:expr,} => {
+        impl<T> Rand for [T; $n] {
+            fn rand<R: Rng>(_rng: &mut R) -> [T; $n] { [] }
+        }
+    };
+}
+
+array_impl!{32, T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T T}
+
 impl<T:Rand> Rand for Option<T> {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> Option<T> {


### PR DESCRIPTION
There are certain use cases where a `Rand` implementation for small arrays is useful. I therefore implemented them for all arrays with size <= 32.